### PR TITLE
Enables toggle behaviour like Bootstrap accordion

### DIFF
--- a/addon/accordion-item.js
+++ b/addon/accordion-item.js
@@ -99,7 +99,7 @@ export default Em.Component.extend(WithConfigMixin, {
    */
   selectByParam: (function() {
     var idx;
-    if ((this.get('accordion.selected') != null) === this) {
+    if (this.get('accordion.selected') === this) {
       return;
     }
     idx = parseInt(this.get('accordion.selected-idx', 10));

--- a/addon/accordion-item.js
+++ b/addon/accordion-item.js
@@ -85,10 +85,10 @@ export default Em.Component.extend(WithConfigMixin, {
    *
    * Bound to `click` event.
    *
-   * @method select
+   * @method toggle
    */
-  select: (function() {
-    return this.get('accordion').select(this);
+  toggle: (function() {
+    return this.get('accordion').toggle(this);
   }).on('click'),
 
   /**
@@ -104,7 +104,7 @@ export default Em.Component.extend(WithConfigMixin, {
     }
     idx = parseInt(this.get('accordion.selected-idx', 10));
     if (idx === this.get('index')) {
-      return this.select();
+      return this.toggle();
     }
   }).observes('accordion.selected-idx').on('didInsertElement'),
 

--- a/addon/accordion.js
+++ b/addon/accordion.js
@@ -42,6 +42,24 @@ export default Em.Component.extend(WithConfigMixin, {
   },
 
   /**
+   * Toggle the given item.
+   *
+   * @method toggle
+   * @param {Object} an item instance to select.
+   */
+  toggle: function(item) {
+    if (this.get('selected') === item) {
+      Em.debug("Unsecting item: " + (item.get('index')));
+      this.unselect();
+    } else {
+      Em.debug("Selecting item: " + (item.get('index')));
+      this.select(item);
+    }
+
+    return this.get('selected');
+  },
+
+  /**
    * Select the given item.
    *
    * @method select
@@ -51,8 +69,18 @@ export default Em.Component.extend(WithConfigMixin, {
     if (!item) {
       return;
     }
-    Em.debug("Selecting item: " + (item.get('index')));
+
     this.set('selected', item);
     return this.set('selected-idx', item.get('index'));
+  },
+
+  /**
+   * Clears accordion selection.
+   *
+   * @method unselect
+   */
+  unselect: function() {
+    this.set('selected', undefined);
+    return this.set('selected-idx', -1);
   }
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.4.0"
   },
   "description": "Ambitious Accordion Component for Ember.js",
   "authors": [


### PR DESCRIPTION
Hides selected panel when the user clicks on it again, like Bootstrap accordion behaviour (closes #3):

![ezgif com-video-to-gif 2](https://cloud.githubusercontent.com/assets/387579/8084739/0499d04c-0f63-11e5-9a32-67590a3dfc21.gif)

Also, I fixed a strange behaviour: accordion select function was called twice when the panel was clicked by the user. You can see this through the console:

![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/387579/8084695/c9b355ac-0f62-11e5-9f9a-a1d010fe5b9b.gif)
