### PR TITLE
Switch click handler to an action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+
+# intellij
+.idea

--- a/addon/accordion-item.js
+++ b/addon/accordion-item.js
@@ -99,7 +99,7 @@ export default Em.Component.extend(WithConfigMixin, {
    */
   selectByParam: (function() {
     var idx;
-    if ((this.get('accordion.selected') != null) === this) {
+    if (this.get('accordion.selected') === this) {
       return;
     }
     idx = parseInt(this.get('accordion.selected-idx', 10));

--- a/addon/accordion-item.js
+++ b/addon/accordion-item.js
@@ -81,17 +81,6 @@ export default Em.Component.extend(WithConfigMixin, {
   }).property('selected'),
 
   /**
-   * Select this item.
-   *
-   * Bound to `click` event.
-   *
-   * @method toggle
-   */
-  toggle: (function() {
-    return this.get('accordion').toggle(this);
-  }).on('click'),
-
-  /**
    * Select this item if it matches the {{#crossLink "Accordiong/select:method"}}selected-idx{{/crossLink}} property set by the Accordion component.
    *
    * @method selectByAccordionParam
@@ -104,7 +93,7 @@ export default Em.Component.extend(WithConfigMixin, {
     }
     idx = parseInt(this.get('accordion.selected-idx', 10));
     if (idx === this.get('index')) {
-      return this.toggle();
+      return this.get('accordion').toggle(this)
     }
   }).observes('accordion.selected-idx').on('didInsertElement'),
 
@@ -130,5 +119,10 @@ export default Em.Component.extend(WithConfigMixin, {
     var $accordionBody;
     $accordionBody = this.$('.panel-collapse');
     return $accordionBody.addClass('in');
+  },
+  actions: {
+    toggle: function() {
+      return this.get('accordion').toggle(this);
+    }
   }
 });

--- a/addon/accordion-item.js
+++ b/addon/accordion-item.js
@@ -85,10 +85,10 @@ export default Em.Component.extend(WithConfigMixin, {
    *
    * Bound to `click` event.
    *
-   * @method select
+   * @method toggle
    */
-  select: (function() {
-    return this.get('accordion').select(this);
+  toggle: (function() {
+    return this.get('accordion').toggle(this);
   }).on('click'),
 
   /**
@@ -104,7 +104,7 @@ export default Em.Component.extend(WithConfigMixin, {
     }
     idx = parseInt(this.get('accordion.selected-idx', 10));
     if (idx === this.get('index')) {
-      return this.select();
+      return this.toggle();
     }
   }).observes('accordion.selected-idx').on('didInsertElement'),
 

--- a/addon/accordion.js
+++ b/addon/accordion.js
@@ -42,6 +42,24 @@ export default Em.Component.extend(WithConfigMixin, {
   },
 
   /**
+   * Toggle the given item.
+   *
+   * @method toggle
+   * @param {Object} an item instance to select.
+   */
+  toggle: function(item) {
+    if (this.get('selected') === item) {
+      Em.debug("Unsecting item: " + (item.get('index')));
+      this.unselect();
+    } else {
+      Em.debug("Selecting item: " + (item.get('index')));
+      this.select(item);
+    }
+
+    return this.get('selected');
+  },
+
+  /**
    * Select the given item.
    *
    * @method select
@@ -51,8 +69,18 @@ export default Em.Component.extend(WithConfigMixin, {
     if (!item) {
       return;
     }
-    Em.debug("Selecting item: " + (item.get('index')));
+
     this.set('selected', item);
     return this.set('selected-idx', item.get('index'));
+  },
+
+  /**
+   * Clears accordion selection.
+   *
+   * @method unselect
+   */
+  unselect: function() {
+    this.set('selected', undefined);
+    return this.set('selected-idx', -1);
   }
 });

--- a/app/templates/components/em-accordion-item.hbs
+++ b/app/templates/components/em-accordion-item.hbs
@@ -5,7 +5,7 @@
 <!--panel-collapse collapse-->
 <!--panel-body-->
 <div {{bind-attr class=panelHeaderClasses}}>
-    <h4 {{bind-attr class=panelTitleClasses}} style="cursor: pointer;">
+    <h4 {{action "toggle"}} {{bind-attr class=panelTitleClasses}} style="cursor: pointer;">
         <a {{bind-attr class=panelTogglerClasses}}>
             {{view.title}}
         </a>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.4.0"
   },
   "description": "Ambitious Accordion Component for Ember.js",
   "authors": [


### PR DESCRIPTION
This builds on https://github.com/indexiatech/ember-idx-accordion/pull/4 and removes the click handler from the component and swaps it to an action on the title

PR 4 switches everything over to a toggle mechanism, this PR ensures that only the header of the accordion toggles the accordion. This might be more bootstrap centric - but is important to ensure that specific content of the accordion itself doesn't toggle the accordion
