### PR TITLE
Fix Ember 2.0 deprecation

### DIFF
--- a/app/templates/components/em-accordion-item.hbs
+++ b/app/templates/components/em-accordion-item.hbs
@@ -7,7 +7,7 @@
 <div class={{panelHeaderClasses}}>
     <h4 bind-attr class={{panelTitleClasses}} style="cursor: pointer;">
         <a bind-attr class={{panelTogglerClasses}}>
-            {{view.title}}
+            {{title}}
         </a>
     </h4>
 </div>

--- a/app/templates/components/em-accordion-item.hbs
+++ b/app/templates/components/em-accordion-item.hbs
@@ -4,13 +4,13 @@
 
 <!--panel-collapse collapse-->
 <!--panel-body-->
-<div {{bind-attr class=panelHeaderClasses}}>
-    <h4 {{bind-attr class=panelTitleClasses}} style="cursor: pointer;">
-        <a {{bind-attr class=panelTogglerClasses}}>
+<div class={{panelHeaderClasses}}>
+    <h4 bind-attr class={{panelTitleClasses}} style="cursor: pointer;">
+        <a bind-attr class={{panelTogglerClasses}}>
             {{view.title}}
         </a>
     </h4>
 </div>
-<div {{bind-attr class=panelBodyContainerClasses}}>
-    <div {{bind-attr class=panelBodyClasses}}>{{yield}}</div>
+<div bind-attr class={{panelBodyContainerClasses}}>
+    <div bind-attr class={{panelBodyClasses}}>{{yield}}</div>
 </div>


### PR DESCRIPTION
To fix:

DEPRECATION: The `bind-attr` helper ('bv-ember-application/templates/components/em-accordion-item.hbs' @ L7:C7) is deprecated in favor of HTMLBars-style bound attributes.
